### PR TITLE
use DESTDIR/PREFIX variables and install(1) in the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 # This is a makefile for gtkshutdown
 # URL < https://github.com/giorgosioak/gtkshutdown >
 
+DESTDIR ?=
+PREFIX ?= /usr
+
 CFLAGS=-Wall `pkg-config --cflags --libs gtk+-3.0 libnotify libcanberra` -export-dynamic -no-pie
 
 all:
@@ -17,11 +20,10 @@ run: all
 rebuild: clean all
 
 install: all
-	sudo cp build/gtkshutdown /usr/bin/gtkshutdown
-	sudo chmod +x /usr/bin/gtkshutdown
-
+	install -Dm 755 build/gtkshutdown $(DESTDIR)/$(PREFIX)/bin/gtkshutdown
+	
 uninstall:
-	sudo rm -f /usr/bin/gtkshutdown
+	rm -f $(DESTDIR)/$(PREFIX)/bin/gtkshutdown
 	
 clean:
 	rm -rf build data/gtkshutdown.c


### PR DESCRIPTION
The change enables staged installs using the the GNU coding standards for [DESTDIR](https://www.gnu.org/prep/standards/html_node/DESTDIR.html) and common use of the PREFIX variables. PREFIX is set by default to _/usr_ instead of the better _/usr/local_ to ensure backwards compatibility.
_install(1)_ is used in place of the cp and chmod commands with sudo. In package building sudo may not be available in a restricted package building environment.