### PR TITLE
Added support for sleep/suspend operation

### DIFF
--- a/data/window_main.glade
+++ b/data/window_main.glade
@@ -12,11 +12,6 @@
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
-  <object class="GtkImage" id="image1">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-missing-image</property>
-  </object>
   <object class="GtkImage" id="logout_img">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -43,6 +38,12 @@
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="stock">gtk-quit</property>
+    <property name="icon_size">6</property>
+  </object>
+  <object class="GtkImage" id="sleep_img">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-media-pause</property>
     <property name="icon_size">6</property>
   </object>
   <object class="GtkWindow" id="window_main">
@@ -107,6 +108,9 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
+                <property name="image">sleep_img</property>
+                <property name="image-position">top</property>
+                <property name="always-show-image">True</property>
                 <signal name="clicked" handler="sleep_clicked_cb" object="timer_box" swapped="no"/>
               </object>
               <packing>

--- a/data/window_main.glade
+++ b/data/window_main.glade
@@ -12,6 +12,11 @@
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-missing-image</property>
+  </object>
   <object class="GtkImage" id="logout_img">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -97,6 +102,20 @@
               </packing>
             </child>
             <child>
+              <object class="GtkButton" id="sleep">
+                <property name="label" translatable="yes">Sleep</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="sleep_clicked_cb" object="timer_box" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="shutdown">
                 <property name="label" translatable="yes">Power Off</property>
                 <property name="visible">True</property>
@@ -110,7 +129,7 @@
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -79,6 +79,7 @@ void sleep_clicked_cb (GtkButton *shutdown, GtkWidget *timer_box) {
 		sprintf(options,"%d",timeInMins);
 		notify_user("System will halt in %s minutes", options);
 		play_alert_sound();
+		g_free(options);
 		system(command);
 	} else {
 		play_alert_sound();

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -61,6 +61,32 @@ void restart_clicked_cb (GtkButton *restart, GtkWidget *timer_box) {
 	g_free(command);
 }
 
+// called when sleep button clicked
+void sleep_clicked_cb (GtkButton *shutdown, GtkWidget *timer_box) {
+
+	int timeInMins = 0;
+	char* options = malloc(OPTIONS_SIZE);
+	char* command = malloc(COMMAND_SIZE);
+
+	// Get timer
+	GtkWidget *timer = find_child(timer_box,"timer");
+
+	// If timer is checked
+	if (gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(timer))) {
+		timeInMins = get_shutdown_timer_options_in_minutes(timer_box);
+		g_assert(timeInMins > 0);
+		snprintf(command, COMMAND_SIZE, "systemd-run --user --on-active=%dmin /bin/systemctl suspend", timeInMins);
+		sprintf(options,"%d",timeInMins);
+		notify_user("System will halt in %s minutes", options);
+		play_alert_sound();
+		system(command);
+	} else {
+		play_alert_sound();
+		system("systemctl suspend");
+	}
+	g_free(command);
+}
+
 // called when shutdown button clicked
 void shutdown_clicked_cb (GtkButton *shutdown, GtkWidget *timer_box) {
 

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -19,6 +19,7 @@
 #include <canberra.h>
 #include <gtk/gtk.h>
 #include <libnotify/notify.h>
+#include <time.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -51,6 +52,35 @@ char* get_shutdown_timer_options (GtkWidget *timer_box){
     } else {
         return g_strdup_printf("%d:%d", at_hours, at_minutes);
     }
+}
+
+int get_shutdown_timer_options_in_minutes (GtkWidget *timer_box) {
+    char* ret = malloc( 64 * sizeof(char) );        memset(ret, 0, 64);
+    char* hours = malloc( 20 * sizeof(char) );      memset(hours, 0, 20);
+    char* minutes = malloc( 20 * sizeof(char) );    memset(minutes, 0, 20);
+    time_t T = time(NULL);
+    struct tm time = *localtime(&T);
+
+    // Get (GtkGrid) timer_options
+    GtkWidget *timer_options = find_child(timer_box,"timer_options");
+
+    // Get (GtkRadioButton) radio_in
+    GtkWidget *radio_in = find_child(timer_options,"radio_in");
+
+    // Get hours and minutes values from GtkSpinButton
+    int in_hours = gtk_spin_button_get_value( (GtkSpinButton *) find_child(timer_options,"in_hours"));
+    int in_minutes = gtk_spin_button_get_value( (GtkSpinButton *) find_child(timer_options,"in_minutes"));
+    int at_hours = gtk_spin_button_get_value( (GtkSpinButton *) find_child(timer_options,"at_hours"));
+    int at_minutes = gtk_spin_button_get_value( (GtkSpinButton *) find_child(timer_options,"at_minutes"));
+
+    // Check if radio_in is active. If radio_in is not active then radio_at is active
+    if (gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(radio_in))) {
+        return in_hours * 60 + in_minutes;
+    } else {
+        int system_time_mins = time.tm_hour * 60 + time.tm_min;
+        int selected_time_mins = at_hours * 60 + at_minutes;
+        return selected_time_mins - system_time_mins;
+    }    
 }
 
 // find child in container

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -21,6 +21,8 @@
 // transform hours and minutes to shutdown options format
 char* get_shutdown_timer_options (GtkWidget *timer_box);
 
+int get_shutdown_timer_options_in_minutes (GtkWidget *timer_box);
+
 /* find child in container
  * thanks to Darius Kucinskas ( @dkucinskas ) */
 GtkWidget* find_child(GtkWidget* parent, const gchar* name);


### PR DESCRIPTION
1. Added a "Sleep" button with a respective icon in the glade file
2. Created a utility function called `get_shutdown_timer_options_in_minutes` to help with time formatting for use by the `systemd suspend` command
3. Implemented the callback function that allows the system to go into suspend/sleep mode either via a timer set by the user, or instantly

Resolves #3  